### PR TITLE
Fix RabbitMQ queue name

### DIFF
--- a/mvc-user/src/main/java/com/alerta_sp/mvc_user/config/RabbitMQConfig.java
+++ b/mvc-user/src/main/java/com/alerta_sp/mvc_user/config/RabbitMQConfig.java
@@ -10,16 +10,11 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class RabbitMQConfig {
 
-    public static final String ALERTA_QUEUE_USUARIO = "alerta.queue.usuario";
-
-    @Bean
-    public Queue usuarioQueue() {
-        return new Queue(ALERTA_QUEUE_USUARIO, true);
-    }
+    public static final String ALERTA_QUEUE = "alertas.queue";
 
     @Bean
     public Queue alertaQueue() {
-        return new Queue("alertas.queue", true);
+        return new Queue(ALERTA_QUEUE, true);
     }
 
     @Bean

--- a/mvc-user/src/main/resources/application.properties
+++ b/mvc-user/src/main/resources/application.properties
@@ -19,7 +19,7 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 spring.datasource.hikari.connection-init-sql=SET NAMES utf8mb4
 
 #Mensageria
-rabbitmq.queue=alerta.queue.usuario
+rabbitmq.queue=alertas.queue
 spring.rabbitmq.host=localhost
 spring.rabbitmq.port=5672
 spring.rabbitmq.username=guest


### PR DESCRIPTION
## Summary
- use a single queue declaration in RabbitMQConfig
- align queue name with the admin app
- update application.properties accordingly

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684335a637dc832b81c8060ba7c6dfea