### PR TITLE
Fix RabbitMQ consumer lazy init issue

### DIFF
--- a/mvc-user/src/main/java/com/alerta_sp/mvc_user/messaging/AlertaConsumer.java
+++ b/mvc-user/src/main/java/com/alerta_sp/mvc_user/messaging/AlertaConsumer.java
@@ -9,6 +9,7 @@ import com.alerta_sp.mvc_user.repository.UsuarioRepository;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 public class AlertaConsumer {
@@ -30,8 +31,14 @@ public class AlertaConsumer {
 
     // 📩 Listener ativado por mensagens do RabbitMQ
     @RabbitListener(queues = "${rabbitmq.queue}")
+    @Transactional
     public void consumirAlerta(AlertaMensagemDTO dto) {
         System.out.println("✅ Alerta recebido: " + dto);
+
+        if (dto.getIdCorrego() == null) {
+            System.err.println("❌ Mensagem recebida sem id do córrego: " + dto);
+            return;
+        }
 
         // 1. Buscar córrego
         Corrego corrego = corregoRepository.findById(dto.getIdCorrego())


### PR DESCRIPTION
## Summary
- handle messages without stream ID
- wrap alerta consumer method in a transaction

## Testing
- `mvn -q -f mvc-user/pom.xml -DskipTests package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68433fed5b80832b902079bbeeb3793c