### PR TITLE
Fix date formatting in dashboard

### DIFF
--- a/mvc-user/src/main/resources/templates/dashboard.html
+++ b/mvc-user/src/main/resources/templates/dashboard.html
@@ -164,7 +164,7 @@
         </thead>
         <tbody>
         <tr th:each="alerta : ${ultimosAlertas}">
-            <td th:text="${#dates.format(alerta.dataHora, 'dd/MM/yyyy HH:mm')}"></td>
+            <td th:text="${#temporals.format(alerta.dataHora, 'dd/MM/yyyy HH:mm')}"></td>
             <td th:text="${alerta.corrego}"></td>
             <td th:text="${alerta.tipo}"></td>
             <td th:text="${alerta.mensagem}"></td>


### PR DESCRIPTION
## Summary
- use `#temporals.format` for `LocalDateTime` fields in the dashboard template

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_6845fc0d76e4832b83bdd72d74a2476d