### PR TITLE
Fix queue name configuration

### DIFF
--- a/mvc-user/src/main/java/com/alerta_sp/mvc_user/config/RabbitMQConfig.java
+++ b/mvc-user/src/main/java/com/alerta_sp/mvc_user/config/RabbitMQConfig.java
@@ -6,15 +6,14 @@ import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.beans.factory.annotation.Value;
 
 @Configuration
 public class RabbitMQConfig {
 
-    public static final String ALERTA_QUEUE = "alertas.queue";
-
     @Bean
-    public Queue alertaQueue() {
-        return new Queue(ALERTA_QUEUE, true);
+    public Queue alertaQueue(@Value("${rabbitmq.queue}") String queueName) {
+        return new Queue(queueName, true);
     }
 
     @Bean

--- a/mvc-user/src/main/java/com/alerta_sp/mvc_user/messaging/AlertaConsumer.java
+++ b/mvc-user/src/main/java/com/alerta_sp/mvc_user/messaging/AlertaConsumer.java
@@ -30,7 +30,7 @@ public class AlertaConsumer {
     }
 
     // 📩 Listener ativado por mensagens do RabbitMQ
-    @RabbitListener(queues = "alertas.fila")
+    @RabbitListener(queues = "${rabbitmq.queue}")
     @Transactional
     public void consumirAlerta(MensagemAlertaDTO dto) {
         System.out.println("✅ Alerta recebido: " + dto);


### PR DESCRIPTION
## Summary
- align RabbitMQ queue name with application properties
- inject queue name into listener via `${rabbitmq.queue}`

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_684601e1d800832b9bdb33223c9826f5