### PR TITLE
Fix alert type null handling

### DIFF
--- a/mvc-user/src/main/java/com/alerta_sp/mvc_user/messaging/AlertaConsumer.java
+++ b/mvc-user/src/main/java/com/alerta_sp/mvc_user/messaging/AlertaConsumer.java
@@ -47,7 +47,12 @@ public class AlertaConsumer {
         // 2. Salvar alerta
         Alerta alerta = new Alerta();
         alerta.setMensagem(dto.getMensagem());
-        alerta.setTipo(TipoAlerta.valueOf(dto.getTipo().toUpperCase()));
+
+        String tipo = dto.getTipo() != null
+                ? dto.getTipo().toUpperCase()
+                : "DESCONHECIDO";
+
+        alerta.setTipo(TipoAlerta.valueOf(tipo));
         alerta.setCorrego(corrego);
         alerta.setStatus("ATIVO");
         alerta.setResolvido(false);


### PR DESCRIPTION
## Summary
- guard against null values for alert type in `AlertaConsumer`

## Testing
- `mvnw -q test` *(fails: Non-resolvable parent POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684610455d4c832b9a501e7b7bbded55